### PR TITLE
toggle added for password inputs on sign in and up

### DIFF
--- a/recap.md
+++ b/recap.md
@@ -1441,3 +1441,4 @@ File Changes:
     - Added Poppins font import and cn utility; applied Poppins className to footer text for typography styling only.
 - Whitespace cleanup
   - src/modules/home/ui/components/search-filters/categories.tsx
+    - Removed two blank lines around a hidden measurement block; no functional changes.

--- a/src/modules/auth/ui/views/sign-in-view.tsx
+++ b/src/modules/auth/ui/views/sign-in-view.tsx
@@ -23,6 +23,8 @@ import {
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { loginSchema } from '../../schemas';
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
 
 const poppins = Poppins({
   subsets: ['latin'],
@@ -30,6 +32,8 @@ const poppins = Poppins({
 });
 
 function SignInView() {
+  const [showPassword, setShowPassword] = useState(false);
+
   const router = useRouter();
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -109,11 +113,35 @@ function SignInView() {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel className="text-base">Password</FormLabel>
-                  <FormControl>
-                    {/* spreading the field ensures you have all the things like onChange onBlur and state */}
-                    <Input {...field} type="password" />
-                  </FormControl>
-
+                  <div className="relative">
+                    <FormControl>
+                      {/* spreading the field ensures you have all the things like onChange onBlur and state */}
+                      <Input
+                        {...field}
+                        type={showPassword ? 'text' : 'password'}
+                        autoComplete="current-password"
+                        className="pr-12"
+                      />
+                    </FormControl>
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((v) => !v)}
+                      onMouseDown={(e) =>
+                        e.preventDefault()
+                      } /* keep cursor focus in input */
+                      aria-label={
+                        showPassword ? 'Hide password' : 'Show password'
+                      }
+                      aria-pressed={showPassword}
+                      className="absolute inset-y-0 right-2 my-auto h-8 rounded px-2"
+                    >
+                      {showPassword ? (
+                        <Eye className="cursor-pointer" />
+                      ) : (
+                        <EyeOff className="cursor-pointer" />
+                      )}
+                    </button>
+                  </div>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/modules/auth/ui/views/sign-in-view.tsx
+++ b/src/modules/auth/ui/views/sign-in-view.tsx
@@ -101,7 +101,7 @@ function SignInView() {
                   <FormLabel className="text-base">Email</FormLabel>
                   <FormControl>
                     {/* spreading the field ensures you have all the things like onChange onBlur and state */}
-                    <Input {...field} />
+                    <Input {...field} autoComplete="email" />
                   </FormControl>
 
                   <FormMessage />

--- a/src/modules/auth/ui/views/sign-up-view.tsx
+++ b/src/modules/auth/ui/views/sign-up-view.tsx
@@ -135,7 +135,7 @@ function SignUpView() {
                   <FormLabel className="text-base">Username</FormLabel>
                   <FormControl>
                     {/* spreading the field ensures you have all the things like onChange onBlur and state */}
-                    <Input {...field} />
+                    <Input {...field} autoComplete="username" />
                   </FormControl>
                   <FormDescription
                     className={cn('hidden', showPreview && 'block')}
@@ -173,10 +173,13 @@ function SignUpView() {
                       <Input
                         {...field}
                         type={showPassword ? 'text' : 'password'}
+                        autoComplete="new-password"
+                        className="pr-12"
                       />
                     </FormControl>
                     <button
                       type="button"
+                      className="absolute inset-y-0 right-2 my-auto h-8 rounded px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       onClick={() => setShowPassword((v) => !v)}
                       onMouseDown={(e) =>
                         e.preventDefault()
@@ -185,7 +188,6 @@ function SignUpView() {
                         showPassword ? 'Hide password' : 'Show password'
                       }
                       aria-pressed={showPassword}
-                      className="absolute inset-y-0 right-2 my-auto h-8 rounded px-2"
                     >
                       {showPassword ? (
                         <Eye className="cursor-pointer" />

--- a/src/modules/auth/ui/views/sign-up-view.tsx
+++ b/src/modules/auth/ui/views/sign-up-view.tsx
@@ -24,6 +24,8 @@ import {
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { registerSchema } from '../../schemas';
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
 
 const poppins = Poppins({
   subsets: ['latin'],
@@ -31,6 +33,8 @@ const poppins = Poppins({
 });
 
 function SignUpView() {
+  const [showPassword, setShowPassword] = useState(false);
+
   const router = useRouter();
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -163,11 +167,33 @@ function SignUpView() {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel className="text-base">Password</FormLabel>
-                  <FormControl>
-                    {/* spreading the field ensures you have all the things like onChange onBlur and state */}
-                    <Input {...field} type="password" />
-                  </FormControl>
-
+                  <div className="relative">
+                    <FormControl>
+                      {/* spreading the field ensures you have all the things like onChange onBlur and state */}
+                      <Input
+                        {...field}
+                        type={showPassword ? 'text' : 'password'}
+                      />
+                    </FormControl>
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((v) => !v)}
+                      onMouseDown={(e) =>
+                        e.preventDefault()
+                      } /* keep cursor focus in input */
+                      aria-label={
+                        showPassword ? 'Hide password' : 'Show password'
+                      }
+                      aria-pressed={showPassword}
+                      className="absolute inset-y-0 right-2 my-auto h-8 rounded px-2"
+                    >
+                      {showPassword ? (
+                        <Eye className="cursor-pointer" />
+                      ) : (
+                        <EyeOff className="cursor-pointer" />
+                      )}
+                    </button>
+                  </div>
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a password visibility toggle to Sign In and Sign Up forms, preserving focus, updating accessible labels/pressed state, and switching between hidden and plain text without changing validation or submission. Inputs now include appropriate autocomplete hints (email, username, current/new password).

- **Style**
  - Minor whitespace cleanup in UI code with no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->