### PR TITLE
Group product list items into order-level cards

### DIFF
--- a/src/app/(app)/(auth)/sign-in/page.tsx
+++ b/src/app/(app)/(auth)/sign-in/page.tsx
@@ -9,6 +9,7 @@ export const dynamic = 'force-dynamic';
  *
  * @returns The `SignInView` element when no active user session exists.
  * @remarks When an active session with a user is present, initiates a redirect to `'/'` via Next.js redirect mechanism.
+ * CodeRabbit keeps telling you to add a try catch here. IGNORE IT. It fucks shit up.
  */
 export default async function Page() {
   const session = await caller.auth.session();

--- a/src/app/(app)/(auth)/sign-in/page.tsx
+++ b/src/app/(app)/(auth)/sign-in/page.tsx
@@ -8,7 +8,7 @@ export const dynamic = 'force-dynamic';
  * Render the sign-in page, redirecting to the homepage when a user session exists.
  *
  * @returns The `SignInView` element when no active user session exists.
- * @throws When an active session with a user is present, a redirect to `'/'` is initiated and may throw.
+ * @remarks When an active session with a user is present, initiates a redirect to `'/'` via Next.js redirect mechanism.
  */
 export default async function Page() {
   const session = await caller.auth.session();

--- a/src/app/(app)/(auth)/sign-in/page.tsx
+++ b/src/app/(app)/(auth)/sign-in/page.tsx
@@ -1,22 +1,13 @@
 import { redirect } from 'next/navigation';
-
 import SignInView from '@/modules/auth/ui/views/sign-in-view';
 import { caller } from '@/trpc/server';
 
-
-
 export const dynamic = 'force-dynamic';
 
-const Page = async () => {
-  try {
-    const session = await caller.auth.session();
-    if (session.user) {
-      redirect('/');
-    }
-  } catch (error) {
-    console.error('Failed to fetch session', error);
+export default async function Page() {
+  const session = await caller.auth.session();
+  if (session?.user) {
+    redirect('/'); // throws; do not catch
   }
   return <SignInView />;
-};
-
-export default Page;
+}

--- a/src/lib/orders/types.ts
+++ b/src/lib/orders/types.ts
@@ -1,0 +1,15 @@
+export type OrderWithItems = {
+  id: string;
+  name?: string | null; // e.g. "Guitar effects pedal (+2 more)"
+  total: number; // cents
+  currency?: string | null;
+  items?: OrderItemLite[];
+};
+
+export type OrderItemLite = {
+  id?: string;
+  nameSnapshot?: string | null;
+  // put your image path here:
+  imageUrl?: string | null;
+  product?: { image?: { url?: string | null } } | null; // if you store images on product
+};

--- a/src/lib/orders/utils.ts
+++ b/src/lib/orders/utils.ts
@@ -1,0 +1,22 @@
+import { OrderWithItems } from './types';
+
+export function dedupeOrdersById<T extends { id: string }>(rows: T[]): T[] {
+  return Array.from(new Map(rows.map((order) => [order.id, order])).values());
+}
+
+export function computeOrderTitle(o: OrderWithItems): string {
+  if (o.name) return o.name;
+
+  const first = o.items?.[0];
+  if (!first) return 'Order';
+
+  const base = first.nameSnapshot || 'Order';
+  const extra = (o.items?.length ?? 0) - 1;
+  return extra > 0 ? `${base} (+${extra} more)` : base;
+}
+
+export function computeOrderCover(o: OrderWithItems): string {
+  const first = o.items?.[0];
+  // Prefer a snapshot if you store it, else fall back to product image, else placeholder
+  return first?.imageUrl || first?.product?.image?.url || '/placeholder.png';
+}

--- a/src/modules/library/ui/components/invoice-dialog.tsx
+++ b/src/modules/library/ui/components/invoice-dialog.tsx
@@ -53,9 +53,12 @@ export default function InvoiceDialog(props: InvoiceDialogProps) {
   } = props;
   const [isDownloading, setIsDownloading] = useState(false);
   const currency = (order?.currency ?? 'USD').toUpperCase();
-
   const lineItems: OrderItem[] = useMemo(() => {
-    if (order?.items && order.items.length > 0) return order.items;
+    // If the order came with items, render them all—no fallback.
+    if (Array.isArray(order?.items) && order.items.length > 0) {
+      return order.items;
+    }
+    // Fallback to 1 line if you opened the modal from a card without fetching the full order yet
     const qty = order?.quantity ?? 1;
     const total = order?.totalCents ?? 0;
     const unit = Math.round(total / Math.max(qty, 1));

--- a/src/modules/library/ui/components/product-list.tsx
+++ b/src/modules/library/ui/components/product-list.tsx
@@ -26,7 +26,9 @@ export const ProductList = () => {
   const rows = data?.pages.flatMap((p) => p.docs) ?? [];
 
   // 2) Group ONLY by orderId (skip rows without an orderId)
-  const byOrder = new Map<string, typeof rows>();
+  // const byOrder = new Map<string, typeof rows>();
+  type Row = (typeof rows)[number];
+  const byOrder = new Map<string, Row[]>();
   for (const row of rows) {
     if (typeof row.orderId !== 'string' || row.orderId.length === 0) continue;
     const bucket = byOrder.get(row.orderId) ?? [];
@@ -35,31 +37,27 @@ export const ProductList = () => {
   }
 
   // 3) One card per order
-  const cards = Array.from(byOrder.entries())
-    .filter(([, items]) => items.length > 0)
-    .map(([orderId, items]) => {
-      const first = items[0]!;
-      const extraCount = items.length - 1;
+  const cards = Array.from(byOrder.entries()).map(([orderId, items]) => {
+    const first = items[0]!;
+    const extraCount = items.length - 1;
 
-      // Safe base title from the first item; never undefined
-      const baseTitle =
-        (typeof first.name === 'string' && first.name) || 'Order';
+    // Safe base title from the first item; never undefined
+    const baseTitle = (typeof first.name === 'string' && first.name) || 'Order';
 
-      const title =
-        extraCount > 0 ? `${baseTitle} (+${extraCount} more)` : baseTitle;
+    const title =
+      extraCount > 0 ? `${baseTitle} (+${extraCount} more)` : baseTitle;
 
-      return {
-        orderId,
-        title,
-        imageURL: first.image?.url ?? null,
-        tenantSlug: first.tenant?.slug ?? '',
-        tenantImageURL: first.tenant?.image?.url ?? null,
-        reviewRating:
-          typeof first.reviewRating === 'number' ? first.reviewRating : 0,
-        reviewCount:
-          typeof first.reviewCount === 'number' ? first.reviewCount : 0
-      };
-    });
+    return {
+      orderId,
+      title,
+      imageURL: first.image?.url ?? null,
+      tenantSlug: first.tenant?.slug ?? '',
+      tenantImageURL: first.tenant?.image?.url ?? null,
+      reviewRating:
+        typeof first.reviewRating === 'number' ? first.reviewRating : 0,
+      reviewCount: typeof first.reviewCount === 'number' ? first.reviewCount : 0
+    };
+  });
 
   if (cards.length === 0) {
     return (

--- a/src/modules/library/ui/components/product-list.tsx
+++ b/src/modules/library/ui/components/product-list.tsx
@@ -14,43 +14,79 @@ export const ProductList = () => {
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage } =
     useSuspenseInfiniteQuery(
       trpc.library.getMany.infiniteQueryOptions(
+        { limit: DEFAULT_LIMIT },
         {
-          limit: DEFAULT_LIMIT
-        },
-        {
-          getNextPageParam: (lastPage) => {
-            return lastPage.docs.length > 0 ? lastPage.nextPage : undefined;
-          }
+          getNextPageParam: (lastPage) =>
+            lastPage.docs.length > 0 ? lastPage.nextPage : undefined
         }
       )
     );
 
-  if (!data?.pages || data.pages[0]?.docs.length === 0) {
+  // 1) Flatten
+  const rows = data?.pages.flatMap((p) => p.docs) ?? [];
+
+  // 2) Group ONLY by orderId (skip rows without an orderId)
+  const byOrder = new Map<string, typeof rows>();
+  for (const row of rows) {
+    if (typeof row.orderId !== 'string' || row.orderId.length === 0) continue;
+    const bucket = byOrder.get(row.orderId) ?? [];
+    bucket.push(row);
+    byOrder.set(row.orderId, bucket);
+  }
+
+  // 3) One card per order
+  const cards = Array.from(byOrder.entries())
+    .filter(([, items]) => items.length > 0)
+    .map(([orderId, items]) => {
+      const first = items[0]!;
+      const extraCount = items.length - 1;
+
+      // Safe base title from the first item; never undefined
+      const baseTitle =
+        (typeof first.name === 'string' && first.name) || 'Order';
+
+      const title =
+        extraCount > 0 ? `${baseTitle} (+${extraCount} more)` : baseTitle;
+
+      return {
+        orderId,
+        title,
+        imageURL: first.image?.url ?? null,
+        tenantSlug: first.tenant?.slug ?? '',
+        tenantImageURL: first.tenant?.image?.url ?? null,
+        reviewRating:
+          typeof first.reviewRating === 'number' ? first.reviewRating : 0,
+        reviewCount:
+          typeof first.reviewCount === 'number' ? first.reviewCount : 0
+      };
+    });
+
+  if (cards.length === 0) {
     return (
       <div className="border border-black border-dashed flex items-center justify-center p-8 flex-col gap-y-4 bg-white rounded-lg">
         <InboxIcon />
-        <p className="text-base font-medium">No products found </p>
+        <p className="text-base font-medium">No orders found</p>
       </div>
     );
   }
+
   return (
     <>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
-        {data?.pages
-          .flatMap((page) => page.docs)
-          .map((product) => (
-            <ProductCard
-              key={product.id}
-              orderId={product.orderId}
-              name={product.name}
-              imageURL={product.image?.url ?? null}
-              tenantSlug={product.tenant?.slug ?? ''}
-              tenantImageURL={product.tenant?.image?.url ?? null}
-              reviewRating={product.reviewRating}
-              reviewCount={product.reviewCount}
-            />
-          ))}
+        {cards.map((c) => (
+          <ProductCard
+            key={c.orderId}
+            orderId={c.orderId}
+            name={c.title}
+            imageURL={c.imageURL}
+            tenantSlug={c.tenantSlug}
+            tenantImageURL={c.tenantImageURL}
+            reviewRating={c.reviewRating}
+            reviewCount={c.reviewCount}
+          />
+        ))}
       </div>
+
       <div className="flex justify-center pt-8">
         {hasNextPage && (
           <Button
@@ -67,12 +103,10 @@ export const ProductList = () => {
   );
 };
 
-export const ProductListSkeleton = () => {
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
-      {Array.from({ length: DEFAULT_LIMIT }).map((_, index) => (
-        <ProductCardSkeleton key={index} />
-      ))}
-    </div>
-  );
-};
+export const ProductListSkeleton = () => (
+  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
+    {Array.from({ length: DEFAULT_LIMIT }).map((_, index) => (
+      <ProductCardSkeleton key={index} />
+    ))}
+  </div>
+);

--- a/src/modules/orders/server/utils.ts
+++ b/src/modules/orders/server/utils.ts
@@ -375,7 +375,9 @@ export type OrderItemDoc =
  * @returns `true` if `val` is an object with an `id` property, `false` otherwise.
  */
 export function isProductObject(val: unknown): val is Product {
-  return !!val && typeof val === 'object' && 'id' in (val as Product);
+  return (
+    !!val && typeof val === 'object' && typeof (val as Product).id === 'string'
+  );
 }
 /**
  * Narrow a value's type to `Tenant` when it contains a `slug` property.
@@ -384,7 +386,9 @@ export function isProductObject(val: unknown): val is Product {
  * @returns `true` if `val` is an object with a `slug` property (a `Tenant`), `false` otherwise.
  */
 export function isTenantObject(val: unknown): val is Tenant {
-  return !!val && typeof val === 'object' && 'slug' in (val as Tenant);
+  return (
+    !!val && typeof val === 'object' && typeof (val as Tenant).slug === 'string'
+  );
 }
 /**
  * Resolve a relational reference to its string identifier.
@@ -409,7 +413,7 @@ export function getRelIdStrict(
  * @returns The numeric input `n` if it is a number, otherwise `fallback`
  */
 export function safeNumber(n: unknown, fallback = 0): number {
-  return typeof n === 'number' ? n : fallback;
+  return typeof n === 'number' && Number.isFinite(n) ? n : fallback;
 }
 /**
  * Normalize a value into a positive integer, using a fallback when invalid.

--- a/src/modules/orders/server/utils.ts
+++ b/src/modules/orders/server/utils.ts
@@ -512,9 +512,12 @@ export function mapOrderToBuyer(doc: Order): OrderForBuyer {
       : null;
 
   const shippingRaw = (doc as { shipping?: unknown }).shipping;
+  const normalizedShipping = readShippingFromOrder(shippingRaw);
   const shipping =
-    readShippingFromOrder(shippingRaw) ??
-    (shippingRaw && typeof shippingRaw === 'object'
+    normalizedShipping ??
+    (shippingRaw &&
+    typeof shippingRaw === 'object' &&
+    !Array.isArray(shippingRaw)
       ? (shippingRaw as OrderForBuyer['shipping'])
       : null);
 

--- a/src/modules/orders/types.ts
+++ b/src/modules/orders/types.ts
@@ -57,6 +57,7 @@ export type OrderSummaryDTO = {
   productId: string;
   productIds?: string[]; // All product IDs in the order when multiple items exist
   shipping?: ShippingAddress;
+  items?: OrderItemDTO[];
 };
 
 type BaseOrderSummaryProps = {

--- a/src/modules/orders/ui/OrderSummaryCard.tsx
+++ b/src/modules/orders/ui/OrderSummaryCard.tsx
@@ -34,8 +34,6 @@ export function OrderSummaryCard(props: OrderSummaryCardProps) {
     totalFormatted = `${currencyCode} ${totalDollars.toFixed(2)}`;
   }
 
-  const quantity = Math.max(1, Number(props.quantity ?? 1) || 1);
-
   const fmtDate = (d?: string | Date | null) => {
     if (!d) return '—';
     const date = typeof d === 'string' ? new Date(d) : d;
@@ -64,7 +62,6 @@ export function OrderSummaryCard(props: OrderSummaryCardProps) {
 
       <CardContent className="grid gap-3 text-sm">
         <Row label="Order date" value={fmtDate(orderDate)} />
-        <Row label="Quantity" value={quantity} />
         <Row label="Total paid" value={totalFormatted} strong />
         <Row
           label="Order #"


### PR DESCRIPTION
…lodates them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Orders view now groups items into one card per order, with clearer titles, cover images, pagination and “No orders found” empty state.
  - Buyers can fetch a full order on demand (invoice button shows loading while fetching) to view richer invoice details.

- Improvements
  - Order summaries now include per-item details.
  - Access expanded so buyer or seller contexts grant appropriate order visibility.
  - Utilities added to dedupe orders and compute titles/covers.

- Bug Fixes
  - Safer invoice line-item handling; removed redundant Quantity row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->